### PR TITLE
Fix for when an object is passed

### DIFF
--- a/src/Valitron/Validator.php
+++ b/src/Valitron/Validator.php
@@ -712,14 +712,20 @@ class Validator
         return count($this->errors()) === 0;
     }
 
-    private function getValueFromPath($array, $path)
+    private function getValueFromPath($fields, $path)
     {
         return array_reduce(
             explode('/', $path),
             function ($o, $p) {
-                return isset($o[$p]) ? $o[$p] : null;
+                if (is_array($o)) {
+                    return isset($o[$p]) ? $o[$p] : null;
+                } elseif (is_object($o)) {
+                    return $o->$p;
+                } else {
+                    return null;
+                }
             },
-            $array
+            $fields
         );
     }
 


### PR DESCRIPTION
The first level gets stored as an array, but now that there can be more than one level it is possible (and usually it will be) that the next level is an object and not an array.